### PR TITLE
README: fix a broken link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@
 :page-description: Learn how to build a MicroProfile application
 :page-tags: ['REST', 'MicroProfile', 'Getting Started', 'CDI']
 :page-permalink: /guides/{projectid}
-:common-includes: ../guides-common/
+:common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master/https://raw.githubusercontent.com/OpenLiberty/guides-common/master/
 :source-highlighter: prettify
 = Creating a MicroProfile application
 


### PR DESCRIPTION
guides-common directory is anways remote,
so directly point the common-includes to the remote

Fixes: #9 
signed-off-by: Gireesh Punathi <gpunathi@in.ibm.com>

Please review! (thanks in advance)