### PR TITLE
Revert "Add the guide release date"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,6 @@
 :projectid: microprofile-intro
 :page-layout: guide
 :page-duration: 30 minutes
-:page-date: 2017-09-19
 :page-description: Learn how to build a MicroProfile application
 :page-tags: ['REST', 'MicroProfile', 'Getting Started', 'CDI']
 :page-permalink: /guides/{projectid}


### PR DESCRIPTION
Reverts OpenLiberty/guide-microprofile-intro#27

`page-date` is causing Jekyll build to break.  Another Asciidoctor attribute will be needed to replace `page-date`.  Until we have the new attribute, revert the introduction of `page-date`.