### PR TITLE
Adding a note on the repo to redirect to cdi guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,8 +18,7 @@
 = Creating a MicroProfile application
 
 [.hidden]
-NOTE: This guide is replaced by https://openliberty.io/guides/rest-intro.html[Creating a RESTful web service
-] and https://openliberty.io/guides/cdi-intro.html[Injecting dependencies into microservices] and has been archived. 
+NOTE: The Creating a MicroProfile application guide has been archived and is replaced by the https://openliberty.io/guides/rest-intro.html[Creating a RESTful web service] guide and the https://openliberty.io/guides/cdi-intro.html[Injecting dependencies into microservices] guide.
 
 Learn how to use JAX-RS, CDI, and JSON-P to build a MicroProfile application.
 

--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,9 @@
 :source-highlighter: prettify
 = Creating a MicroProfile application
 
+[.hidden]
+NOTE: This guide is deprecated. View the introductory guide to MicroProfile in https://openliberty.io/guides/cdi-intro.html[Injecting dependencies into microservices].
+
 Learn how to use JAX-RS, CDI, and JSON-P to build a MicroProfile application.
 
 // =================================================================================================

--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,8 @@
 = Creating a MicroProfile application
 
 [.hidden]
-NOTE: This guide is deprecated. View the introductory guide to MicroProfile in https://openliberty.io/guides/cdi-intro.html[Injecting dependencies into microservices].
+NOTE: This guide is replaced by https://openliberty.io/guides/rest-intro.html[Creating a RESTful web service
+] and https://openliberty.io/guides/cdi-intro.html[Injecting dependencies into microservices] and has been archived. 
 
 Learn how to use JAX-RS, CDI, and JSON-P to build a MicroProfile application.
 

--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@
 = Creating a MicroProfile application
 
 [.hidden]
-NOTE: The Creating a MicroProfile application guide has been archived and is replaced by the https://openliberty.io/guides/rest-intro.html[Creating a RESTful web service] guide and the https://openliberty.io/guides/cdi-intro.html[Injecting dependencies into microservices] guide.
+NOTE: The _Creating a MicroProfile application_ guide has been archived and is replaced by the https://openliberty.io/guides/rest-intro.html[Creating a RESTful web service] guide and the https://openliberty.io/guides/cdi-intro.html[Injecting dependencies into microservices] guide.
 
 Learn how to use JAX-RS, CDI, and JSON-P to build a MicroProfile application.
 


### PR DESCRIPTION
The MP-intro guide is being archived. 
Adding a note on the repo to indicate and link to the cdi-intro guide. 